### PR TITLE
Add clc to _init

### DIFF
--- a/src/entry.s65
+++ b/src/entry.s65
@@ -41,6 +41,7 @@ irq:
 
 _init:
                 sei                
+                clc
                 cld
                 clv
                 ldx #$ff


### PR DESCRIPTION
The value of the carry flag is undefined at startup, so we should clear
it explicitly.